### PR TITLE
fix CLA script to run with github actions instead of travis

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Test
+        if: github.event_name == 'pull_request'
+        run: ./cla-check.sh CONTRIBUTORS.csv
+        env:
+          COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-sudo: false
-script:
-  - ./cla-travis.sh CONTRIBUTORS.csv

--- a/cla-check.sh
+++ b/cla-check.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-[ "$TRAVIS_PULL_REQUEST" == false ] && exit 0
-
 CLA_URL="https://github.com/shapesecurity/CLA"
 if [ $# -gt 0 ]; then
   CLA_CSV_URL="$1"
@@ -12,15 +10,20 @@ else
   CSV_DATA=`curl "$CLA_CSV_URL" 2>/dev/null | tail -n +2`
 fi
 
+if [ -z "$COMMIT_RANGE" ]; then
+  echo "COMMIT_RANGE must be provided"
+  exit 1
+fi
+
 echo "CLA_CSV_URL: $CLA_CSV_URL"
-echo "TRAVIS_COMMIT_RANGE: $TRAVIS_COMMIT_RANGE"
+echo "COMMIT_RANGE: $COMMIT_RANGE"
 echo
 
 CONTRIBUTORS=(`echo "$CSV_DATA" | awk -F, '/,/{gsub(/ /, "", $0); print $2 "@users.noreply.github.com"; print $4}'`)
 CONTRIBUTORS=" ${CONTRIBUTORS[*]} "
 
 
-AUTHORS=(`git log --pretty=format:"%ae" $TRAVIS_COMMIT_RANGE | sort -u`)
+AUTHORS=(`git log --pretty=format:"%ae" $COMMIT_RANGE | sort -u`)
 echo "Authors in this range: ${AUTHORS[@]}"
 
 for item in ${AUTHORS[@]}; do
@@ -33,7 +36,7 @@ for item in ${AUTHORS[@]}; do
 done
 
 
-COMMITTERS=(`git log --pretty=format:"%ce" $TRAVIS_COMMIT_RANGE | sort -u`)
+COMMITTERS=(`git log --pretty=format:"%ce" $COMMIT_RANGE | sort -u`)
 echo "Committers in this range: ${COMMITTERS[@]}"
 
 for item in ${COMMITTERS[@]}; do

--- a/cla-check.sh
+++ b/cla-check.sh
@@ -27,7 +27,7 @@ AUTHORS=(`git log --pretty=format:"%ae" $COMMIT_RANGE | sort -u`)
 echo "Authors in this range: ${AUTHORS[@]}"
 
 for item in ${AUTHORS[@]}; do
-  if [[ ! ("$item" == *"@shapesecurity.com" || "$item" == *"+dependabot[bot]@users.noreply.github.com" || "$CONTRIBUTORS" =~ " $item ") ]]; then
+  if [[ ! ("$item" == *"@shapesecurity.com" || "$item" == *"@f5.com" || "$item" == *"+dependabot[bot]@users.noreply.github.com" || "$CONTRIBUTORS" =~ " $item ") ]]; then
     echo
     echo "ERROR: Author $item has not signed the CLA"
     echo
@@ -40,7 +40,7 @@ COMMITTERS=(`git log --pretty=format:"%ce" $COMMIT_RANGE | sort -u`)
 echo "Committers in this range: ${COMMITTERS[@]}"
 
 for item in ${COMMITTERS[@]}; do
-  if [[ ! ("$item" == "noreply@github.com" || "$item" == *"@shapesecurity.com" || "$CONTRIBUTORS" =~ " $item ") ]]; then
+  if [[ ! ("$item" == "noreply@github.com" || "$item" == *"@shapesecurity.com" || "$item" == *"@f5.com" || "$CONTRIBUTORS" =~ " $item ") ]]; then
     echo
     echo "ERROR: Committer $item has not signed the CLA"
     echo


### PR DESCRIPTION
This needs to be run in a github action with the following job.

```yml
jobs:
  pre:
    name: Prerequisites
    runs-on: ubuntu-latest

    steps:
      - name: Checkout
        uses: actions/checkout@v2
        with:
          fetch-depth: 0

      - name: Enforce CLA signature
        if: github.event_name == 'pull_request'
        env:
          COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
        run: curl https://raw.githubusercontent.com/shapesecurity/CLA/HEAD/cla-travis.sh | bash
```

Some crucial bits:
- `fetch-depth 0` so that it fetches the full history (so it can check all the commits on the branch); 
- guarded on being on a PR (instead of the script itself doing this)
- setting $COMMIT_RANGE, which github does not provide for you (unlike travis)
  - it's possible to parse these out of an JSON file github puts in the runner, as I understand it, but that's more annoying.


---

Also makes @f5.com email addresses automatically pass.